### PR TITLE
Fix displaying empty blogs list on author page

### DIFF
--- a/blacktail/templates/blacktail/author_page.html
+++ b/blacktail/templates/blacktail/author_page.html
@@ -53,13 +53,13 @@
           </ul>
         {% endif %}
 
-        {% if model.stories.live %}
+        {% if model.blogs.live %}
           <hr>
           <h5>Blog posts by {{model.name}}:</h5>
           <ul>
-            {% for story in model.blogs.live %}
+            {% for post in model.blogs.live %}
             <li>
-              <a href="{{ story.url }}"> {{ story.title }} </a>
+              <a href="{{ post.url }}"> {{ post.title }} </a>
             </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
I've just seen this:
![image](https://user-images.githubusercontent.com/1579997/47872287-d2ad0000-de16-11e8-9720-3301344404e2.png)

Minor fix in diff.